### PR TITLE
fix: resolve dead links in documentation

### DIFF
--- a/src/guides/build-iapp/advanced/quick-start.md
+++ b/src/guides/build-iapp/advanced/quick-start.md
@@ -80,7 +80,7 @@ You are now familiar with the following key iExec concepts for developers:
 
 Continue with these guides:
 
-- [Learn how to build your first condiential application running on iExec](/guides/build-iapp/advanced/build-your-first-sgx-iapp.md)
+- [Learn how to build your first confidential application running on iExec](/guides/build-iapp/advanced/build-your-first-sgx-iapp.md)
 
 <script setup>
 import { computed } from 'vue';

--- a/src/protocol/ai.md
+++ b/src/protocol/ai.md
@@ -19,10 +19,10 @@ optimized configurations.
 - 📚
   **[AI Frameworks Hello World](https://github.com/iExecBlockchainComputing/ai-frameworks-hello-world)** -
   Ready-to-use Docker examples for TensorFlow, PyTorch, and more
-- 🛠️ **[Build & Deploy](/guides/build-iapp/build-&-deploy)** - General iApp
+- 🛠️ **[Build & Test](/guides/build-iapp/build-&-test)** - General iApp
   development guide (not AI-specific)
 - 🔬
-  **[TDX App Guide](/guides/build-iapp/advanced/create-your-first-tdx-app)** -
+  **[TDX App Guide](/guides/build-iapp/advanced/build-your-first-tdx-iapp)** -
   Build TDX applications (works well for AI workloads)
 
 ## 🛡️ Why iExec for AI?


### PR DESCRIPTION
- Fix typo: 'condiential' -> 'confidential' in quick-start.md
- Fix broken link: 'build-&-deploy' -> 'build-&-test' in ai.md
- Fix broken link: 'create-your-first-tdx-app' -> 'build-your-first-tdx-iapp' in ai.md