### PR TITLE
docs(navigation): move glossary to iExec overview section

### DIFF
--- a/.vitepress/sidebar.ts
+++ b/.vitepress/sidebar.ts
@@ -71,6 +71,10 @@ export function getSidebar() {
             text: 'RLC Token',
             link: '/get-started/overview/rlc',
           },
+          {
+            text: '📖 Glossary',
+            link: '/get-started/overview/glossary',
+          },
         ],
       },
       {
@@ -377,10 +381,6 @@ export function getSidebar() {
       {
         text: 'iExec SDK',
         link: '/references/sdk',
-      },
-      {
-        text: '📖 Glossary',
-        link: '/references/glossary',
       },
     ],
     '/protocol/': [

--- a/src/get-started/overview/glossary.md
+++ b/src/get-started/overview/glossary.md
@@ -450,4 +450,3 @@ mainchain.
 
 See [Sidechain](#sidechain), [Bellecour Sidechain](#bellecour-sidechain) or
 [Minting](#minting) for more information.
-

--- a/src/get-started/overview/glossary.md
+++ b/src/get-started/overview/glossary.md
@@ -115,7 +115,7 @@ authorized people can enter and where everything inside is protected.
 
 ### Explorer (iExec Explorer)
 
-Tracks and displays all transactions occurring on iExec’s platform. It provides
+Tracks and displays all transactions occurring on iExec's platform. It provides
 detailed information on the latest deals, tasks, apps, and datasets deployed.
 
 ### ERC-20
@@ -450,3 +450,4 @@ mainchain.
 
 See [Sidechain](#sidechain), [Bellecour Sidechain](#bellecour-sidechain) or
 [Minting](#minting) for more information.
+

--- a/src/protocol/proof-of-contribution.md
+++ b/src/protocol/proof-of-contribution.md
@@ -75,7 +75,8 @@ consensus on a given result. Two blog articles detail its logic:
 
 The
 [nominal workflow](https://github.com/iExecBlockchainComputing/iexec-doc/raw/master/techreport/nominalworkflow-ODB.png)
-is also available in the [technical report section](/get-started/overview/glossary)
+is also available in the
+[technical report section](/get-started/overview/glossary)
 
 Below are the details of the implementations:
 

--- a/src/protocol/proof-of-contribution.md
+++ b/src/protocol/proof-of-contribution.md
@@ -75,7 +75,7 @@ consensus on a given result. Two blog articles detail its logic:
 
 The
 [nominal workflow](https://github.com/iExecBlockchainComputing/iexec-doc/raw/master/techreport/nominalworkflow-ODB.png)
-is also available in the [technical report section](/references/glossary)
+is also available in the [technical report section](/get-started/overview/glossary)
 
 Below are the details of the implementations:
 

--- a/src/protocol/tee/intel-sgx.md
+++ b/src/protocol/tee/intel-sgx.md
@@ -15,9 +15,9 @@ decentralized cloud.
 
 ## What is Intel SGX?
 
-[Intel® SGX](https://software.intel.com/en-us/sgx) creates a special secure
-zone in memory called an "enclave" - think of it as a vault that only the CPU
-can access. Neither the operating system nor any other software can see what's
+[Intel® SGX](https://software.intel.com/en-us/sgx) creates a special secure zone
+in memory called an "enclave" - think of it as a vault that only the CPU can
+access. Neither the operating system nor any other software can see what's
 happening inside this protected area. Your code and data are completely private
 and secure.
 
@@ -66,11 +66,10 @@ graph TB
 
 ### SGX limitations
 
-With native Intel® SGX technology, the OS is not a part of the Trusted
-Computing Base (TCB), hence system calls and kernel services are not available
-from an Intel® SGX enclave. This can be limiting as the application will not be
-able to use file system and sockets directly from the code running inside the
-enclave.
+With native Intel® SGX technology, the OS is not a part of the Trusted Computing
+Base (TCB), hence system calls and kernel services are not available from an
+Intel® SGX enclave. This can be limiting as the application will not be able to
+use file system and sockets directly from the code running inside the enclave.
 
 ### iExec's SGX infrastructure
 

--- a/src/protocol/tee/intel-sgx.md
+++ b/src/protocol/tee/intel-sgx.md
@@ -15,9 +15,9 @@ decentralized cloud.
 
 ## What is Intel SGX?
 
-[Intel® SGX](https://software.intel.com/en-us/sgx) creates a special secure zone
-in memory called an "enclave" - think of it as a vault that only the CPU can
-access. Neither the operating system nor any other software can see what's
+[Intel® SGX](https://software.intel.com/en-us/sgx) creates a special secure
+zone in memory called an "enclave" - think of it as a vault that only the CPU
+can access. Neither the operating system nor any other software can see what's
 happening inside this protected area. Your code and data are completely private
 and secure.
 
@@ -66,10 +66,11 @@ graph TB
 
 ### SGX limitations
 
-With native Intel® SGX technology, the OS is not a part of the Trusted Computing
-Base (TCB), hence system calls and kernel services are not available from an
-Intel® SGX enclave. This can be limiting as the application will not be able to
-use file system and sockets directly from the code running inside the enclave.
+With native Intel® SGX technology, the OS is not a part of the Trusted
+Computing Base (TCB), hence system calls and kernel services are not available
+from an Intel® SGX enclave. This can be limiting as the application will not be
+able to use file system and sockets directly from the code running inside the
+enclave.
 
 ### iExec's SGX infrastructure
 


### PR DESCRIPTION
Moved the glossary page from the references section to the iExec overview section in the sidebar.

The glossary is now positioned as the last item in the iExec OVERVIEW section, making it more accessible to users learning about iExec.

Updated all internal references to point to the new location.