### PR TITLE
docs: update Discord invite link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -143,7 +143,7 @@ export default withMermaid(
       socialLinks: [
         { icon: 'github', link: 'https://github.com/iExecBlockchainComputing' },
         { icon: 'x', link: 'https://x.com/iEx_ec' },
-        { icon: 'discord', link: 'https://discord.com/invite/pbt9m98wnU' },
+        { icon: 'discord', link: 'https://discord.com/invite/5TewNUnJHN' },
       ],
 
       editLink: {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,7 +373,7 @@ vale src/
 ## 🆘 Support and Help
 
 - 📖 [Documentation](https://docs.iex.ec)
-- 💬 [Discord Community](https://discord.com/invite/pbt9m98wnU)
+- 💬 [Discord Community](https://discord.com/invite/5TewNUnJHN)
 - 🐛
   [Issue Tracker](https://github.com/iExecBlockchainComputing/documentation/issues)
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,6 @@ for input parameters:
 ## 🆘 Support
 
 - 📖 [Documentation](https://docs.iex.ec)
-- 💬 [Discord Community](https://discord.com/invite/pbt9m98wnU)
+- 💬 [Discord Community](https://discord.com/invite/5TewNUnJHN)
 - 🐛
   [Issue Tracker](https://github.com/iExecBlockchainComputing/documentation/issues)

--- a/src/get-started/overview/workerpool.md
+++ b/src/get-started/overview/workerpool.md
@@ -70,11 +70,11 @@ Workerpool selection automatically.
 Workerpool in action
 
 **Join as Worker:**
-[Contact us on Discord](https://discord.com/invite/pbt9m98wnU) for guidance and
+[Contact us on Discord](https://discord.com/invite/5TewNUnJHN) for guidance and
 support
 
 **Manage Workerpool:**
-[Contact us on Discord](https://discord.com/invite/pbt9m98wnU) for deployment
+[Contact us on Discord](https://discord.com/invite/5TewNUnJHN) for deployment
 assistance
 
 </CardWithoutBorder>

--- a/src/guides/build-iapp/advanced/build-your-first-tdx-iapp.md
+++ b/src/guides/build-iapp/advanced/build-your-first-tdx-iapp.md
@@ -17,7 +17,7 @@ TDX support is currently in experimental phase:
 
 - Stability and confidentiality features are still being tested and refined.
 - Features may evolve based on user feedback, please share your experience on
-  [Discord](https://discord.com/invite/pbt9m98wnU).
+  [Discord](https://discord.com/invite/5TewNUnJHN).
 
 :::
 

--- a/src/protocol/ai.md
+++ b/src/protocol/ai.md
@@ -177,4 +177,4 @@ docker run --rm hello-pytorch
 
 - **[AI Frameworks Hello World](https://github.com/iExecBlockchainComputing/ai-frameworks-hello-world)** -
   Ready-to-use Docker examples
-- **[iExec Discord](https://discord.com/invite/pbt9m98wnU)** - Community support
+- **[iExec Discord](https://discord.com/invite/5TewNUnJHN)** - Community support

--- a/src/protocol/pay-per-task.md
+++ b/src/protocol/pay-per-task.md
@@ -48,5 +48,5 @@ For commands and examples, see the
 
 ::: info Need help Can’t find an order that fits your needs or unsure which
 category to choose?
-[Contact us on Discord](https://discord.com/invite/pbt9m98wnU) and we will help
+[Contact us on Discord](https://discord.com/invite/5TewNUnJHN) and we will help
 you pick the right setup. :::

--- a/src/references/iapp-generator.md
+++ b/src/references/iapp-generator.md
@@ -99,7 +99,7 @@ applications:
 
 - **[Complete Guides](/guides/build-iapp/build-&-test)** - All development
   guides
-- **[iExec Discord](https://discord.com/invite/pbt9m98wnU)** - Community support
+- **[iExec Discord](https://discord.com/invite/5TewNUnJHN)** - Community support
 
 ---
 


### PR DESCRIPTION
Update Discord invite to come from Martin instead of Blair to ensure it remains valid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Discord community link to the new invite across configuration and documentation.
> 
> - Replaces Discord URL in `socialLinks` within `vitepress/config.ts`
> - Updates links in `CONTRIBUTING.md` and `README.md`
> - Refreshes Discord references in docs pages: `workerpool.md`, `build-your-first-tdx-iapp.md`, `ai.md`, `pay-per-task.md`, and `iapp-generator.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc773115b4a0c2ec265cebeb0c00fa65099a027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->