### PR TITLE
fix: Update installation commands for iapp packages

### DIFF
--- a/src/guides/build-iapp/build-&-test.md
+++ b/src/guides/build-iapp/build-&-test.md
@@ -35,19 +35,19 @@ First, install iApp Generator in your project (for more details see
 ::: code-group
 
 ```bash [npm]
-npm install -g @iexec/iapp-generator
+npm install -g @iexec/iapp
 ```
 
 ```bash [yarn]
-yarn global add @iexec/iapp-generator
+yarn global add @iexec/iapp
 ```
 
 ```bash [pnpm]
-pnpm add -g @iexec/iapp-generator
+pnpm add -g @iexec/iapp
 ```
 
 ```bash [bun]
-bun add -g @iexec/iapp-generator
+bun add -g @iexec/iapp
 ```
 
 :::


### PR DESCRIPTION
iexec/iapp-generator to iexec/iapp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates package installation commands; no runtime or security impact.
> 
> **Overview**
> Updates the *Build and Test an iApp* guide to install the CLI from `@iexec/iapp` instead of `@iexec/iapp-generator` across npm/yarn/pnpm/bun examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5154a4848f3245fd26d92742afbd8b2e38e22d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->