### PR TITLE
fix: update Scone image

### DIFF
--- a/src/guides/build-iapp/advanced/build-your-first-sgx-iapp.md
+++ b/src/guides/build-iapp/advanced/build-your-first-sgx-iapp.md
@@ -275,7 +275,7 @@ IMG_TO=<docker-hub-user>/tee-scone-hello-world:1.0.0
 docker run -it --rm \
             -v $PWD/enclave-key.pem:/sig/enclave-key.pem \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            registry.scontain.com/scone-production/iexec-sconify-image:5.9.1-v16\
+            registry.scontain.com/scone-production/iexec-sconify-image:5.9.2-v16 \
             sconify_iexec \
             --scone-signer=/sig/enclave-key.pem \
             --from=${IMG_FROM} \
@@ -304,7 +304,7 @@ IMG_TO=<docker-hub-user>/tee-scone-hello-world:1.0.0
 docker run -it --rm \
             -v $PWD/enclave-key.pem:/sig/enclave-key.pem \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            registry.scontain.com/scone-production/iexec-sconify-image:5.9.1-v16\
+            registry.scontain.com/scone-production/iexec-sconify-image:5.9.2-v16 \
             sconify_iexec \
             --from=${IMG_FROM} \
             --to=${IMG_TO} \


### PR DESCRIPTION
5.9.1-v16 to 5.9.2-v16
fix DOCKER API VERSION

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change updating a referenced Docker image tag; no runtime code changes.
> 
> **Overview**
> Updates the Scone iApp tutorial to use `registry.scontain.com/scone-production/iexec-sconify-image:5.9.2-v16` (from `5.9.1-v16`) in both JavaScript and Python `sconify.sh` examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 656b5a931c937599b8f9be8732017f65b021dba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->