### PR TITLE
feat: redirect Nox Protocol links to docs.noxprotocol.io

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -11,12 +11,12 @@ import govIcon from '@/assets/icons/gov.svg';
 
 const router = useRouter();
 
-function isNoxLink(link: string) {
-  return link.startsWith('/nox-protocol');
+function isExternalLink(link: string) {
+  return link.startsWith('https://');
 }
 
 function handleCardClick(link: string) {
-  if (isNoxLink(link)) {
+  if (isExternalLink(link)) {
     window.location.href = link;
   } else {
     router.go(link);
@@ -32,8 +32,8 @@ const protocolCards = [
       "I'm a Solidity developer and I want to build a confidential smart contract.",
     description:
       'Nox is a privacy layer that empowers smart contracts with confidential computation. Encrypted types are executed inside Trusted Execution Environments (TEE), composable with DeFi, without ever exposing plaintext on-chain.',
-    link: '/nox-protocol/getting-started/welcome',
-    external: false,
+    link: 'https://docs.noxprotocol.io/',
+    external: true,
   },
   {
     icon: pocoIcon,
@@ -53,19 +53,19 @@ const financialFeatures = [
     icon: ctokenIcon,
     title: 'Confidential Token',
     description: 'Transform any ERC-20 into a confidential asset.',
-    link: '/nox-protocol/guides/build-confidential-tokens/intro',
+    link: 'https://docs.noxprotocol.io/guides/build-confidential-tokens/intro',
   },
   {
     icon: smartContractsIcon,
     title: 'Confidential Smart Contracts',
     description: 'Write standard Solidity contracts using the Nox Library.',
-    link: '/nox-protocol/guides/build-confidential-smart-contracts/intro',
+    link: 'https://docs.noxprotocol.io/guides/build-confidential-smart-contracts/intro',
   },
   {
     icon: helloWorldIcon,
     title: 'Nox Hello World',
     description: 'Learn how to build on Nox with the Hello World guide.',
-    link: '/nox-protocol/getting-started/hello-world',
+    link: 'https://docs.noxprotocol.io/getting-started/hello-world',
   },
 ];
 
@@ -127,7 +127,7 @@ const dappFeatures = [
         <a
           v-for="card in protocolCards"
           :key="card.title"
-          :href="isNoxLink(card.link) ? undefined : card.link"
+          :href="isExternalLink(card.link) ? undefined : card.link"
           class="protocol-card"
           @click.stop.prevent="handleCardClick(card.link)"
         >
@@ -154,7 +154,7 @@ const dappFeatures = [
           <a
             v-for="feature in financialFeatures"
             :key="feature.title"
-            :href="isNoxLink(feature.link) ? undefined : feature.link"
+            :href="isExternalLink(feature.link) ? undefined : feature.link"
             class="feature-card"
             @click.stop.prevent="handleCardClick(feature.link)"
           >
@@ -180,7 +180,7 @@ const dappFeatures = [
           <a
             v-for="feature in dappFeatures"
             :key="feature.title"
-            :href="isNoxLink(feature.link) ? undefined : feature.link"
+            :href="isExternalLink(feature.link) ? undefined : feature.link"
             class="feature-card"
             @click.stop.prevent="handleCardClick(feature.link)"
           >

--- a/vercel.json
+++ b/vercel.json
@@ -3,17 +3,17 @@
   "buildCommand": "npm run build",
   "outputDirectory": ".vitepress/dist",
   "cleanUrls": true,
-  "rewrites": [
-    {
-      "source": "/nox-protocol",
-      "destination": "https://documentation-yi1w.vercel.app/nox-protocol/"
-    },
+  "redirects": [
     {
       "source": "/nox-protocol/:path+",
-      "destination": "https://documentation-yi1w.vercel.app/nox-protocol/:path+"
-    }
-  ],
-  "redirects": [
+      "destination": "https://docs.noxprotocol.io/:path+",
+      "permanent": true
+    },
+    {
+      "source": "/nox-protocol",
+      "destination": "https://docs.noxprotocol.io/",
+      "permanent": true
+    },
     {
       "source": "/robots.txt",
       "destination": "/robots-prod.txt",


### PR DESCRIPTION
## Summary

Separates Nox Protocol from `docs.iex.ec` to prevent AI crawlers (ChatGPT, Claude, Cursor) from confusing Nox with DataProtector and other iExec products when they coexist on the same domain.

### Changes

**`src/components/HomePage.vue`**
- Nox Protocol card now links to `https://docs.noxprotocol.io/` instead of `/nox-protocol/getting-started/welcome`
- All Nox feature cards (Confidential Token, Confidential Smart Contracts, Hello World) updated to `docs.noxprotocol.io` URLs
- Renamed `isNoxLink()` helper to generic `isExternalLink()` (checks for `https://` prefix)

**`vercel.json`**
- Removed rewrites that proxied `/nox-protocol/*` to the nox-documentation Vercel project
- Added 301 permanent redirects: `docs.iex.ec/nox-protocol/*` → `docs.noxprotocol.io/*`
- Preserves all existing links shared in the wild

### Related PR
- iExec-Nox/documentation#66 — migrates the Nox docs site itself to serve at root `/` on `docs.noxprotocol.io`

### Prerequisites before merging
1. DNS for `docs.noxprotocol.io` must be configured and propagated
2. iExec-Nox/documentation#66 must be merged first

## Test plan
- [ ] Verify Nox Protocol card on homepage links to `https://docs.noxprotocol.io/`
- [ ] Verify feature cards (Confidential Token, Smart Contracts, Hello World) link to correct `docs.noxprotocol.io` pages
- [ ] Verify `docs.iex.ec/nox-protocol/getting-started/welcome` returns 301 redirect to `docs.noxprotocol.io/getting-started/welcome`
- [ ] Verify `docs.iex.ec/nox-protocol` returns 301 redirect to `docs.noxprotocol.io/`
- [ ] Verify iExec PoCo card and other internal links still work normally