### PR TITLE
fix: redirect /nox-protocol/ trailing slash to docs.noxprotocol.io

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": ".vitepress/dist",
   "cleanUrls": true,
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/nox-protocol/:path*",

--- a/vercel.json
+++ b/vercel.json
@@ -5,8 +5,8 @@
   "cleanUrls": true,
   "redirects": [
     {
-      "source": "/nox-protocol/:path+",
-      "destination": "https://docs.noxprotocol.io/:path+",
+      "source": "/nox-protocol/:path*",
+      "destination": "https://docs.noxprotocol.io/:path*",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Problème

`https://docs.iex.ec/nox-protocol/` (avec slash final) renvoie un **404**.

La règle `/nox-protocol/:path+` exige au moins un segment de chemin. Avec un slash final et un path vide, `/nox-protocol/` ne matche ni cette règle ni la règle `/nox-protocol` (sans slash) → 404.

## Correctif

`:path+` → `:path*` (source **et** destination). Le cas slash-final mappe désormais vers la racine du nouveau domaine.

| URL | Avant | Après |
|-----|-------|-------|
| `/nox-protocol/getting-started/welcome` | 308 ✓ | 308 ✓ |
| `/nox-protocol` | 308 ✓ | 308 ✓ |
| `/nox-protocol/` | **404** ✗ | 308 → docs.noxprotocol.io/ ✓ |

## Test
- `curl -sIL https://<preview>/nox-protocol/` → `30x` → `https://docs.noxprotocol.io/`